### PR TITLE
feat: add screen wake lock to web app

### DIFF
--- a/src/lib/wakelock.ts
+++ b/src/lib/wakelock.ts
@@ -1,0 +1,22 @@
+const requestWakeLock = async () => {
+    if ('wakeLock' in navigator) {
+        try {
+            const wakeLock = await (navigator as any).wakeLock.request('screen')
+
+            wakeLock.onrelease = (e: Event) => console.log(e)
+
+            const handleVisibilityChange = () => {
+                if (wakeLock !== null && document.visibilityState === 'visible') {
+                    requestWakeLock()
+                }
+            }
+
+            document.addEventListener('visibilitychange', handleVisibilityChange)
+        } catch (err) {
+            console.log(err)
+        }
+    }
+}
+
+export default requestWakeLock
+

--- a/src/routes/layout-app.tsx
+++ b/src/routes/layout-app.tsx
@@ -9,6 +9,7 @@ import {
 } from '@builder.io/qwik'
 import Header from '~/components/app/header/header'
 import styles from './app.css?inline'
+import requestWakeLock from '~/lib/wakelock'
 
 export type Interface = {
   zoom: number
@@ -44,6 +45,7 @@ export default component$(() => {
     interfaceStore.mode = getLocalStorage('interfaceMode') ?? 'classic'
     interfaceStore.notes = parseInt(getLocalStorage('interfaceNotes') ?? '0')
     interfaceStore.notesContent = getLocalStorage('interfaceNotesContent') ?? ''
+    requestWakeLock()
   })
   useStyles$(styles)
   return (


### PR DESCRIPTION
close #3

### Summary

Adds a screen wake lock request to app pages. If you go to shabados.com/app it will not work, if you go to shabados.com/app/jap-ji-sahib it will work.

Does not seem to work well on iOS / webkit.

Works on macOS (chrome) and a Dell chromebook.

Will open a bug report for webkit.

### Test

This seemed to work with http and https despite the MDN page details. To do the tests, added `--host` to `npm run start` and configured for the plugin `@vitejs/plugin-basic-ssl`. 

- Determine how long it takes for screen to go blank
- Go to a page in app, wait for ascertained time, screen stays on ✅ 
- Change tabs, wait, screen will sleep
- Go back to shabad os tab, wait, screen stays on ✅ 
- Active tab in browser, change apps, wait, screen stays on ✅ 

### Duration
- Most time was wasted waiting for chromebook screen to turn off (admin mandated 5 mins 30 sec for screen lock) in the tests