### PR TITLE
fix: 🐛 invalid date/time for journey item

### DIFF
--- a/src/components/app/journey/journey.tsx
+++ b/src/components/app/journey/journey.tsx
@@ -7,11 +7,11 @@ import {
 import {
   UiContext,
   UserDataContext,
-  getLocalStorage,
 } from '~/routes/(app)/layout';
 import styles from './journey.css?inline';
 import X from '~/components/icons/ui/x';
 import { useLocation } from '@builder.io/qwik-city';
+import { getUserLocalData, isValidHistoryItem } from '~/lib/localStorage';
 
 
 // Helper function to get category key from timestamp
@@ -70,10 +70,11 @@ export default component$(() => {
   const { url } = useLocation();
 
   useVisibleTask$(() => {
-    userDataStore.history = getLocalStorage('userDataStore')['history'] ?? '{}';
+    userDataStore.history = getUserLocalData().history;
   });
 
   const sortedHistory = Object.entries(userDataStore.history)
+  .filter(([, historyItem]) => isValidHistoryItem(historyItem))
     .sort(([, a], [, b]) => (a['time'] as number) - (b['time'] as number))
     .reverse();
 

--- a/src/lib/localStorage.ts
+++ b/src/lib/localStorage.ts
@@ -2,32 +2,37 @@
 export type HistoryItem = {
   title?: string;
   time?: number;
-  [key: string]: string | number | undefined;
 };
 
-export type PathTimestamp = {
-  [path: string]: HistoryItem;
-};
+export type PathTimestamp = Record<string, HistoryItem>;
+
+export type UserLocalData = {
+  history: PathTimestamp;
+}
 
 /**
- * Get history from localStorage
+ * Get user data from localStorage
  * @param storageKey - The localStorage key (default: 'userDataStore')
- * @returns The history object from localStorage
+ * @returns The user data object from localStorage
  */
-export const getHistory = (storageKey: string = 'userDataStore'): PathTimestamp => {
+export const getUserLocalData = (storageKey: string = 'userDataStore'): UserLocalData => {
   if (typeof window === 'undefined') {
     throw new Error('Tried to access localStorage on the server');
   }
 
   try {
     const data = localStorage.getItem(storageKey);
-    if (!data) return {};
-    
+    if (!data) return {
+      history: {}
+    };
+
     const parsed = JSON.parse(data);
-    return (parsed.history as PathTimestamp) || {};
+    return (parsed as UserLocalData);
   } catch (error) {
     console.warn('Failed to parse history from localStorage:', error);
-    return {};
+    return {
+      history: {}
+    };
   }
 };
 
@@ -48,18 +53,12 @@ export const addHistoryItem = (
 
   try {
     // Get existing data
-    const existingData = localStorage.getItem(storageKey);
-    const userData = existingData ? JSON.parse(existingData) : {};
-    
-    // Ensure history object exists
-    if (!userData.history) {
-      userData.history = {};
-    }
+    const userData = getUserLocalData();
 
     // Add/update the history item with timestamp
     userData.history[path] = {
       ...item,
-      time: item.time || new Date().valueOf(),
+      time: item.time || new Date().valueOf()
     };
 
     // Save back to localStorage
@@ -67,4 +66,9 @@ export const addHistoryItem = (
   } catch (error) {
     console.error('Failed to save history item to localStorage:', error);
   }
+};
+
+
+export const isValidHistoryItem = (item: HistoryItem): boolean => {
+  return typeof item === 'object' && item !== null && 'time' in item && typeof item.time === 'number';
 };


### PR DESCRIPTION
✅ Closes: #50

- handle empty or invalid local storage data
- filter journey list to show only valid date time items